### PR TITLE
Allow option to keep xaxis aligned relative to input

### DIFF
--- a/smooth_pose_traj/include/smooth_pose_traj/smooth_pose_traj.hpp
+++ b/smooth_pose_traj/include/smooth_pose_traj/smooth_pose_traj.hpp
@@ -33,9 +33,25 @@ namespace smooth_pose_traj
 class SmoothPoseTraj
 {
 public:
-  SmoothPoseTraj(const geometry_msgs::PoseArray& input_poses, double point_spacing);
+  /**
+   * @brief Smooth a trajectory using boost cubic b spline
+   * @details By default it aligns the xaxis with the direction of motion.
+   * Set keep_xsign to true if you want the xaxis pointing in the same relative direction as the input
+   * @param input_poses The input trajectory to smooth
+   * @param point_spacing The point spacing of the smooth trajectory
+   * @param keep_xsign If false the xais is align with the direction of motion. If true it will keep the xaxis point in the same relative direction as the input trajectory.
+   */
+  SmoothPoseTraj(const geometry_msgs::PoseArray& input_poses,
+                 double point_spacing,
+                 bool keep_xsign = false);
   virtual ~SmoothPoseTraj() = default;
 
+  /**
+   * @brief Smooth the trajectory and fill out the output_poses
+   * @param output_poses The output trajectory
+   * @param point_spacing The point spacing to use for output trajectory. If less than one it use the point spacing provided in the constructor.
+   * @return True if successful, otherwise false
+   */
   bool process(geometry_msgs::PoseArray& output_poses, double point_spacing = -1);
 
 private:
@@ -46,6 +62,8 @@ private:
   void qnormalize(geometry_msgs::Pose& P);
 
   double point_spacing_, total_distance_, max_t_;
+  bool keep_xsign_{false};
+  double align_sign_{1};
 
   boost::math::cubic_b_spline<double> sx_;
   boost::math::cubic_b_spline<double> sy_;


### PR DESCRIPTION
@drchrislewis This was what was causing the issue on the project flipping the rasters. This add support for the case when xaxis is pointing the opposite direction of motion so it will keep the original xaxis configuration in the smoothed trajectory.